### PR TITLE
Persist S3 client through Bucket __init__

### DIFF
--- a/tc_aws/aws/bucket.py
+++ b/tc_aws/aws/bucket.py
@@ -52,6 +52,20 @@ class Bucket(object):
                 config=config
             )
 
+    async def exists(self, path):
+        """
+        Checks if an object exists at a given path
+        :param string path: Path or 'key' to retrieve AWS object
+        """
+        try:
+            await self._client.head_object(
+                Bucket=self._bucket,
+                Key=self._clean_key(path),
+            )
+        except Exception:
+            return False
+        return True
+
     async def get(self, path):
         """
         Returns object at given path

--- a/tc_aws/aws/bucket.py
+++ b/tc_aws/aws/bucket.py
@@ -11,6 +11,7 @@ from thumbor.engines import BaseEngine
 
 
 class Bucket(object):
+    _client = None
     _instances = {}
 
     @staticmethod
@@ -35,8 +36,6 @@ class Bucket(object):
         """
         self._bucket = bucket
 
-        session = aiobotocore.get_session()
-
         config = None
         if max_retry is not None:
             config = Config(
@@ -45,12 +44,13 @@ class Bucket(object):
                 )
             )
 
-        self._client = session.create_client(
-            's3',
-            region_name=region,
-            endpoint_url=endpoint,
-            config=config
-        )
+        if self._client is None:
+            self._client = aiobotocore.get_session().create_client(
+                's3',
+                region_name=region,
+                endpoint_url=endpoint,
+                config=config
+            )
 
     async def get(self, path):
         """

--- a/tc_aws/loaders/s3_loader.py
+++ b/tc_aws/loaders/s3_loader.py
@@ -63,7 +63,8 @@ async def load(context, url):
         return result
 
     result.successful = True
-    result.buffer = await file_key['Body'].read()
+    async with file_key['Body'] as stream:
+        result.buffer = await stream.read()
 
     result.metadata.update(
         size=file_key['ContentLength'],

--- a/tc_aws/result_storages/s3_storage.py
+++ b/tc_aws/result_storages/s3_storage.py
@@ -60,7 +60,8 @@ class Storage(AwsStorage, BaseStorage):
             return None
 
         result = ResultStorageResult()
-        result.buffer = await key['Body'].read()
+        async with key['Body'] as stream:
+            result.buffer = await stream.read()
         result.successful = True
 
         result.metadata = {

--- a/tc_aws/storages/s3_storage.py
+++ b/tc_aws/storages/s3_storage.py
@@ -109,7 +109,8 @@ class Storage(AwsStorage, BaseStorage):
             logger.warn("[STORAGE] s3 key not found at %s" % crypto_path)
             return None
 
-        file_key = await file_key['Body'].read()
+        async with file_key['Body'] as stream:
+            file_key = await stream.read()
 
         return file_key.decode('utf-8')
 
@@ -129,7 +130,8 @@ class Storage(AwsStorage, BaseStorage):
         if not file_key or self.is_expired(file_key) or 'Body' not in file_key:
             return None
 
-        return loads(await file_key['Body'].read())
+        async with file_key['Body'] as stream:
+            return loads(await stream.read())
 
     async def get(self, path):
         """
@@ -142,7 +144,8 @@ class Storage(AwsStorage, BaseStorage):
         except BotoCoreError:
             return None
 
-        return await file['Body'].read()
+        async with file['Body'] as stream:
+            return await stream.read()
 
     async def exists(self, path):
         """

--- a/tc_aws/storages/s3_storage.py
+++ b/tc_aws/storages/s3_storage.py
@@ -150,15 +150,7 @@ class Storage(AwsStorage, BaseStorage):
         :param string path: Path to check
         """
         file_abspath = self._normalize_path(path)
-
-        try:
-            await self.storage.get(file_abspath)
-        except ClientError as err:
-            if err.response['Error']['Code'] == 'NoSuchKey':
-                return False
-            raise
-
-        return True
+        return await self.storage.exists(file_abspath)
 
     async def remove(self, path):
         """


### PR DESCRIPTION
Our team was tasked to upgrade Thumbor (from 6.7.0) to be able to preserve IPTC metadata. This requires a custom engine https://github.com/scorphus/thumbor-wand-engine, which requires python 3, which requires Thumbor 7.0.0a5. After putting all the pieces together, including the code from @amanagr's PR https://github.com/thumbor-community/aws/pull/147 to accommodate async Thumbor 7, things worked, but we noticed a ton of asyncio errors and a minimum response time of > 3000ms on load testing. 

We utilize S3 loader, loader storage & result storage for our requests, and we noticed that the S3 client creation/Bucket initialization was being called upwards of 5 times for each request.

We took a pass at trying to improve this by only creating the S3 client on Bucket's first __init__ call, and reusing that client for every subsequent request. These changes alone took the minimum response time down to < 200ms (like our 6.7.0 implementation did), and performed very well in load tests (15 containers, numprocs=2, 1000 random requests by 10 users -- same parameters as first load test).

**Update (7/14):** After noticing huge latency spikes with this code in production, we took another pass at optimization. Testing locally I saw that with N number of consecutive requests, processing would get blocked and lead to a ~45 second response. After analyzing the code again I realized that `Bucket.exists` was never actually awaiting the `response['Body'].read()` call from the `storage.get` response, so the stream was never closed, leading to lots of asyncio `Unclosed response` errors (see https://github.com/aio-libs/aiobotocore/issues/68). I updated the exists method to just drop the `storage.get` altogether in favor of using `HeadObject` which is just metadata, no streams to be read from. Then I updated the rest of the `response['Body'].read()` calls to be wrapped in a try/with block so it's more resource-safe. I also removed the extra changes here which @kkopachev recommended leaving out.

I'm very interested to see what you all think. There was a couple other small refactors added as well. Credits to @cselvaraj for the idea & implementation.

cc @amanagr @kkopachev

~~A couple explanations:~~
* ~~The name change from `Storage` -> `S3ResultStorage` class was purely for easier identification in the profiler.~~
* ~~The broad `except Exception` in `s3_storage.py` was added because the NoSuchKey exception wasn't being caught by `ClientError` or `BotoCoreError`, and I couldn't find where NoSuchKey exception actually lives.~~
